### PR TITLE
UI changes from p2b (Saved Topics & Save button)

### DIFF
--- a/templates/partials/category/saved.tpl
+++ b/templates/partials/category/saved.tpl
@@ -1,0 +1,4 @@
+<button id="saved-topics-btn" class="btn btn-ghost-sm d-flex align-items-center gap-2">
+	<i class="fa fa-bookmark text-primary"></i>  
+	<span class="fw-semibold">Saved Topics</span> <!-- Ensure the font weight matches -->
+</button>

--- a/templates/partials/topic-list-bar.tpl
+++ b/templates/partials/topic-list-bar.tpl
@@ -24,6 +24,7 @@
 				<!-- IMPORT partials/category/filter-dropdown-left.tpl -->
 				<!-- IMPORT partials/tags/watch.tpl -->
 				{{{ end }}}
+				<!-- IMPORT partials/category/saved.tpl -->
 				<!-- IMPORT partials/category/tools.tpl -->
 
 				{{{ if (!feeds:disableRSS && rssFeedUrl) }}}

--- a/templates/partials/topics_list.tpl
+++ b/templates/partials/topics_list.tpl
@@ -86,7 +86,13 @@
 		</div>
 
 		<div class="d-flex p-0 col-lg-5 col-12 align-content-stretch">
-			<div class="meta stats d-none d-lg-grid col-6 gap-1 pe-2 text-muted" style="grid-template-columns: 1fr 1fr 1fr;">
+			<div class="d-flex align-items-center gap-1 me-auto">
+				<button id="save-topics-btn" class="btn btn-ghost-sm d-flex align-items-center gap-2">
+					<i class="fa-regular fa-bookmark text-blue"></i>
+					<span class="fw-semibold">Save</span>
+				</button>
+			</div>
+      <div class="meta stats d-none d-lg-grid col-6 gap-1 pe-2 text-muted" style="grid-template-columns: 1fr 1fr 1fr;">
 				{{{ if !reputation:disabled }}}
 				<div class="stats-votes card card-header border-0 p-2 overflow-hidden rounded-1 d-flex flex-column align-items-center">
 					<span class="fs-5 ff-secondary lh-1" title="{./votes}">{humanReadableNumber(./votes, 0)}</span>


### PR DESCRIPTION
I incorporated my parts of UI changes for p2b here. Basically, I added a saved topics button in the thread tools to enable users to see all saved topics. Here is a screenshot of it:
![image](https://github.com/user-attachments/assets/c147e685-4d32-43ad-9d5b-d61f93077fc8)
I also added a saved button for each topic in the topic list, so that users can save topics directly in the category without clicking into the specific topic to save it. Here is a screenshot of it:
![image](https://github.com/user-attachments/assets/c8a9e8e5-fd35-429f-a222-c6a5ec70806a)

This PR resolves #2.
